### PR TITLE
Fix community governance link in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/membership.md
+++ b/.github/ISSUE_TEMPLATE/membership.md
@@ -15,7 +15,7 @@ Role: requested role
 
 ### Requirements
 
-- [ ] I have reviewed the community governance model / guidelines (https://github.com/{{ORGANIZATION}}/community)
+- [ ] I have reviewed the community governance model / guidelines (https://github.com/RobotWebTools/community)
 - [ ] I have enabled 2FA on my GitHub account (https://github.com/settings/security)
 - [ ] I am actively contributing to 1 or more working group subprojects
 


### PR DESCRIPTION
The link was a copy/paste from a template. I've updated it to reference this specific community.